### PR TITLE
use dividebatur 0.9.2

### DIFF
--- a/rivest/api_dividebatur.py
+++ b/rivest/api_dividebatur.py
@@ -286,7 +286,7 @@ class Election:
         counter = cnt.SenateCounter(
             results,
             self.seats,
-            self.data.get_papers_for_count(),
+            self.data.tickets_for_count,
             self.data.get_candidate_ids(),
             self.data.get_candidate_order,
             disable_bulk_exclusions=True)


### PR DESCRIPTION
- update dividebatur, due to minor regression (if a candidate
  held no papers at the start of a count, dividebatur would produce
  a traceback
- minor clarity improvement in api_dividebatur.py
